### PR TITLE
[FEAT] Dockerize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+mysql/

--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,6 @@
 {
     "prefix": "-ft",
     "client": {
-        "token": "<DISCORD_BOT_TOKEN>",
         "intents": [
             "GUILDS",
             "GUILD_MEMBERS",
@@ -19,13 +18,6 @@
                 "sweepInterval": 30
             }
         }
-    },
-    "mysql": {
-        "host": "localhost",
-        "database": "<MYSQL_DATABASE_NAME>",
-        "user": "<MYSQL_USER>",
-        "password": "<MYSQL_PASSWORD>",
-        "connectionLimit": 10
     },
     "jobs": {
         "updateServerCount": {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
     env_file: .env
     environment:
       MYSQL_HOST: mysql
+    depends_on:
+      - mysql
   mysql:
     image: mariadb
     restart: always
@@ -19,8 +21,6 @@ services:
     env_file: .env
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
-    ports:
-      - 3306:3306
   adminer:
     image: adminer
     restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     restart: always
     volumes:
       - ./scripts:/docker-entrypoint-initdb.d
+      - ./mysql:/var/lib/mysql
     env_file: .env
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,11 +21,4 @@ services:
     env_file: .env
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
-  adminer:
-    image: adminer
-    restart: always
-    ports:
-      - 8080:8080
-    environment:
-      ADMINER_DEFAULT_SERVER: mysql
-
+      

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,34 @@
+version: '3.1'
+
+services:
+  bot:
+    image: node:14.9.0
+    restart: always
+    command: npm run start
+    volumes:
+      - .:/usr/src/app
+    working_dir: /usr/src/app
+    environment:
+      MYSQL_HOST: mysql
+      RESPOND_TO_BOT_MESSAGES: ${RESPOND_TO_BOT_MESSAGES}
+      RESPOND_TO_BOT_REACTIONS: ${RESPOND_TO_BOT_REACTIONS}
+  mysql:
+    image: mariadb
+    restart: always
+    volumes:
+      - ./scripts:/docker-entrypoint-initdb.d
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}  
+    ports:
+      - 3306:3306
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
+    environment:
+      ADMINER_DEFAULT_SERVER: mysql
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,20 +8,17 @@ services:
     volumes:
       - .:/usr/src/app
     working_dir: /usr/src/app
+    env_file: .env
     environment:
       MYSQL_HOST: mysql
-      RESPOND_TO_BOT_MESSAGES: ${RESPOND_TO_BOT_MESSAGES}
-      RESPOND_TO_BOT_REACTIONS: ${RESPOND_TO_BOT_REACTIONS}
   mysql:
     image: mariadb
     restart: always
     volumes:
       - ./scripts:/docker-entrypoint-initdb.d
+    env_file: .env
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}  
     ports:
       - 3306:3306
   adminer:


### PR DESCRIPTION
Configure Docker so deployment is as easy at setting a few env variables and running `docker-compose up`.

Sample `.env` file:

```
CLIENT_TOKEN=<token>
MYSQL_DATABASE=friend-time
MYSQL_USER=friend-time
MYSQL_PASSWORD=password
MYSQL_CONNECTION_LIMIT=10
RESPOND_TO_BOT_MESSAGES=true
RESPOND_TO_BOT_REACTIONS=false
```